### PR TITLE
Addition of python script to create GTNP JSON metadata files.

### DIFF
--- a/create_gtnp_metadata_json.py
+++ b/create_gtnp_metadata_json.py
@@ -30,9 +30,11 @@ def traverse(obj, path=None, callback=None):
         path = []
 
     if isinstance(obj, dict):
-        value = {k: traverse(v, path + [k], callback) for k, v in obj.items()}
+        value = dict((k, traverse(v, path + [k], callback))
+                    for k, v in obj.items())
     elif isinstance(obj, list):
-        value = [traverse(elem, path + [idx], callback) for idx, elem in enumerate(obj)]
+        value = [traverse(elem, path + [idx], callback)
+                    for idx, elem in enumerate(obj)]
     else:
         value = obj
 
@@ -41,15 +43,18 @@ def traverse(obj, path=None, callback=None):
     else:
         return callback(path, value)
 
+def strip_whitespace(entry):
+    return entry.strip()
+
 def replace_metadata_values(json_data, replace_fields, csv_data):
     borehole_list = []
     for row in csv_data:
         borehole = {}
-        split_field = [field.split(':') for field in replace_fields]
+        split_fields = [map(strip_whitespace, field.split(':')) for field in replace_fields]
         def transformer(path, value):
-            if path in split_field:
-                replacement_value = row[split_field.index(path)]
-                return replacement_value
+            if path in split_fields:
+                replacement_value = row[split_fields.index(path)]
+                return replacement_value.split()
             else:
                 return value
         borehole = traverse(json_data, callback=transformer)

--- a/create_gtnp_metadata_json.py
+++ b/create_gtnp_metadata_json.py
@@ -1,0 +1,113 @@
+import csv
+import json
+import getopt
+from collections import OrderedDict
+import sys
+
+def read_metadata_csv(csv_overrides):
+    csv_data = []
+    field_names = None
+    is_header = True
+    with open(csv_overrides) as csv_values:
+        reader = csv.reader(csv_values, delimiter=',', quotechar='"')
+        for row in reader:
+            if is_header:
+                field_names = row
+                is_header = False
+            else:
+                csv_data.append(row)
+
+    return field_names, csv_data
+
+def read_json_template(json_template):
+    data = None
+    with open(json_template) as data_file:
+        data = json.load(data_file, object_pairs_hook=OrderedDict)
+    return data
+
+def traverse(obj, path=None, callback=None):
+    if path is None:
+        path = []
+
+    if isinstance(obj, dict):
+        value = {k: traverse(v, path + [k], callback) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        value = [traverse(elem, path + [idx], callback) for idx, elem in enumerate(obj)]
+    else:
+        value = obj
+
+    if callback is None:  # if a callback is provided, call it to get the new value
+        return value
+    else:
+        return callback(path, value)
+
+def replace_metadata_values(json_data, replace_fields, csv_data):
+    borehole_list = []
+    for row in csv_data:
+        borehole = {}
+        split_field = [field.split(':') for field in replace_fields]
+        def transformer(path, value):
+            if path in split_field:
+                replacement_value = row[split_field.index(path)]
+                return replacement_value
+            else:
+                return value
+        borehole = traverse(json_data, callback=transformer)
+        borehole_list.append(borehole)
+    return {'Boreholes':borehole_list}
+
+def create_gtnp_metadata_json(json_template, csv_overrides, out_file):
+    json_metadata = None
+    try:
+        json_metadata = read_json_template(json_template)
+        replace_fields, csv_metadata = read_metadata_csv(csv_overrides)
+        borehole_dict = replace_metadata_values(json_metadata, replace_fields, csv_metadata)
+        with open(out_file, 'w') as json_file:
+            json.dump(borehole_dict, json_file, indent=3)
+    except ValueError as valError:
+        print valError
+
+    return None
+
+def parse_arguments(argv):
+    """ Parse the command line arguments and return them. """
+    json_template = None
+    csv_overrides = None
+    out_file = None
+    try:
+        opts, args = getopt.getopt(argv,"ht:c:o:",["json_template=","csv_overrides=","out_file="])
+    except getopt.GetoptError:
+        print 'create_gtnp_metadata_json.py -t <JSON template file> -c <CSV file with metadata values> -o <CSV output file>'
+        sys.exit(2)
+
+    found_json_template = False
+    found_out_file = False
+    found_csv_overrides = False
+    for opt, arg in opts:
+        if opt == '-h':
+            print 'create_gtnp_metadata_json.py -t <JSON template file> -c <CSV file with metadata values> -o <CSV output file>'
+            sys.exit()
+        elif opt in ("-t", "--json_template"):
+            found_json_template = True
+            json_template = arg
+        elif opt in ("-c", "--csv_overrides"):
+            found_csv_overrides = True
+            csv_overrides = arg
+        elif opt in ("-o", "--out_file"):
+            found_out_file = True
+            out_file = arg
+    if not found_json_template:
+        print "JSON template with common dataset values '-t' argument required."
+        sys.exit(2)
+    if not found_csv_overrides:
+        print "CSV file with entry specific values '-c' argument required."
+        sys.exit(2)
+    if not found_out_file:
+        print "JSON output file '-o' argument required."
+        sys.exit(2)
+    return json_template, csv_overrides, out_file
+
+if __name__ == '__main__':
+    (json_template, csv_overrides, out_file) = parse_arguments(sys.argv[1:])
+
+    create_gtnp_metadata_json(json_template, csv_overrides, out_file)

--- a/create_gtnp_metadata_json.py
+++ b/create_gtnp_metadata_json.py
@@ -1,9 +1,18 @@
+""" Creates list of boreholes in GTNP JSON format using the template file and
+    values in each row in the csv file. """
+
 import csv
 import json
 import getopt
 import sys
 
 def read_metadata_csv(csv_overrides):
+    """
+    Read in the CSV file with dynamic metadata content in each row.
+    :param csv_overrides: File containing dynamic metadata content.
+    :return field_names: list of column names
+    :return csv_data: rows of dynamic metadata
+    """
     csv_data = []
     field_names = None
     is_header = True
@@ -19,12 +28,24 @@ def read_metadata_csv(csv_overrides):
     return field_names, csv_data
 
 def read_json_template(json_template):
+    """
+    Read in JSON template to use for a site/borehole entry.
+    :param json_template: file name of JSON template
+    :return data: JSON data structure from JSON template
+    """
     data = None
     with open(json_template) as data_file:
         data = json.load(data_file)
     return data
 
 def traverse(obj, path=None, callback=None):
+    """
+    Visit all the fields in JSON structure and run callback on every value.
+    :param obj: JSON structure
+    :param path: list of namespace elements to describe field
+    :param callback: function to do something with values
+    :return value: stopping value of recursion or recurse to next level
+    """
     if path is None:
         path = []
 
@@ -47,6 +68,11 @@ def traverse(obj, path=None, callback=None):
         return callback(path, value)
 
 def process_column_name(entry):
+    """
+    Strip extra whitespace from column names and cast integers to numbers.
+    :param entry: column name to clean
+    :return column_name: cleaned up column name
+    """
     column_name = entry.strip()
     try:
         column_name = int(column_name)
@@ -55,6 +81,13 @@ def process_column_name(entry):
     return column_name
 
 def replace_metadata_values(json_data, replace_fields, csv_data):
+    """
+    Coordinates production of final borehole JSON list.
+    :param json_data: individual borehole/site JSON data structure template
+    :param replace_fields: list of JSON fields to replace
+    :param csv_data: rows (one row per borehole/site) of metadata values
+    :return: complete list of populated borehole/site metadata entries
+    """
     borehole_list = []
     for row in csv_data:
         borehole = {}
@@ -76,6 +109,11 @@ def replace_metadata_values(json_data, replace_fields, csv_data):
     return {'Boreholes':borehole_list}
 
 def create_gtnp_metadata_json(json_template, csv_overrides, out_file):
+    """
+    :param json_template: JSON template file name
+    :param csv_overrides: borehole/site metadata values CSV file name
+    :param out_file: file to create with complete JSON metadata dump
+    """
     json_metadata = None
     try:
         json_metadata = read_json_template(json_template)
@@ -85,8 +123,6 @@ def create_gtnp_metadata_json(json_template, csv_overrides, out_file):
             json.dump(borehole_dict, json_file, indent=3)
     except ValueError as valError:
         print valError
-
-    return None
 
 def parse_arguments(argv):
     """ Parse the command line arguments and return them. """

--- a/create_gtnp_metadata_json.py
+++ b/create_gtnp_metadata_json.py
@@ -37,7 +37,7 @@ def traverse(obj, path=None, callback=None):
             value = [traverse(elem, path + [idx], callback)
                      for idx, elem in enumerate(obj)]
         else:
-            value = [traverse(None, path + [0], callback)]
+            value = [traverse('', path + [0], callback)]
     else:
         value = obj
 
@@ -61,8 +61,14 @@ def replace_metadata_values(json_data, replace_fields, csv_data):
         split_fields = [map(process_column_name, field.split(':')) for field in replace_fields]
         def transformer(path, value):
             if path in split_fields:
-                replacement_value = row[split_fields.index(path)]
-                return replacement_value.strip()
+                try:
+                    replacement_value = row[split_fields.index(path)]
+                    if replacement_value:
+                        return replacement_value.strip()
+                    else:
+                        return value
+                except IndexError:
+                    return value
             else:
                 return value
         borehole = traverse(json_data, callback=transformer)

--- a/metadata_test.csv
+++ b/metadata_test.csv
@@ -1,3 +1,4 @@
-name,observation:description,contact:organization:address:country,dataset:country_auth:0,dataset:country_auth:1
-This is a test...,Testing replacing metadata values.,Barbados,
-Seond test name,Second replaced description,Bhutan,Jackson
+name,country_auth,observation:description,contact:organization:address:country,dataset:country_auth:0,dataset:country_auth:1
+This is a test...,,Testing replacing metadata values.,Barbados,,Trinidad-Tobago
+Second test name,Rawhide,Second replaced description,Bhutan,Jackson
+Third test name,,Third replaced description,Tibet,Tibet,India

--- a/metadata_test.csv
+++ b/metadata_test.csv
@@ -1,0 +1,3 @@
+name,observation:description,contact:organization:address:country,dataset:country_auth:0,dataset:country_auth:1
+This is a test...,Testing replacing metadata values.,Barbados,
+Seond test name,Second replaced description,Bhutan,Jackson

--- a/pull_ggd361_data.py
+++ b/pull_ggd361_data.py
@@ -13,13 +13,13 @@ def parse_substation_code(row):
     """ Extract substation code from data row. """
     substation_regex = re.compile(r'\d{4,5}')
     data_code = substation_regex.search(row)
-    return '\"' + row[data_code.end():data_code.end() + 7] + '\"'
+    return '\'' + row[data_code.end():data_code.end() + 7] + '\''
 
 def parse_date_and_time(row):
     """ Extract date/time field from data row. """
     datetime_regex = re.compile(r'\d{8}T\d{4}')
     date_and_time = datetime_regex.search(row)
-    return '\"' + date_and_time.group() + '\"'
+    return '\'' + date_and_time.group() + '\''
 
 def parse_depth(row):
     """ Extract depth field from data row. """
@@ -47,11 +47,9 @@ def parse_row(row):
 
 def pull_data(raw_file, out_file):
     """ Pull data fields out of raw data file. """
-    print 'raw file = ', raw_file
     ifile = codecs.open(raw_file, 'r', encoding='utf_16_le')
-    print 'out file = ', out_file
     ofile = open(out_file, 'w')
-    writer = csv.writer(ofile, delimiter=',', quotechar="'", lineterminator='\n')
+    writer = csv.writer(ofile, delimiter=',', quoting=csv.QUOTE_NONE, lineterminator='\n')
 
     for row in ifile:
         data_row = parse_row(row)

--- a/sort_by_columns.py
+++ b/sort_by_columns.py
@@ -17,7 +17,7 @@ def cast_to_datetime(dt_str):
     """
     date_time = None
     try:
-        date_time = dt.datetime.strptime(dt_str.strip(), gtnp_date_time_format)
+        date_time = dt.datetime.strptime(dt_str, gtnp_date_time_format)
     except ValueError as error:
         print error
     return date_time
@@ -28,7 +28,7 @@ def cast_to_integer(int_str):
     :param int_str: string to convert to an integer
     :return: integer number
     """
-    return int(float(int_str.strip()))
+    return int(float(int_str))
 
 def cast_to_real(real_str):
     """
@@ -36,7 +36,7 @@ def cast_to_real(real_str):
     :param real_str: string to convert to a real
     :return: real number
     """
-    return float(real_str.strip())
+    return float(real_str)
 
 def create_typed_row(row, column_list):
     """
@@ -51,7 +51,7 @@ def create_typed_row(row, column_list):
         if type == 'dt':
             date_time_index = index
             row_list[index] = cast_to_datetime(row_list[index])
-        elif type == 'int':
+        elif type == 'integer':
             row_list[index] = cast_to_integer(row_list[index])
         elif type == 'real':
             row_list[index] = cast_to_real(row_list[index])
@@ -64,7 +64,7 @@ def sort_by_columns(in_file, out_file, column_list):
     :param out_file: sorted CSV file
     :param column_list: list of tuples (index, type) describing sort columns
     """
-    sorted_writer = csv.writer(open(out_file, 'w'), quotechar='"', quoting=csv.QUOTE_NONNUMERIC, lineterminator='\n')
+    sorted_writer = csv.writer(open(out_file, 'w'), quotechar="'", quoting=csv.QUOTE_NONNUMERIC, lineterminator='\n')
     header_row = None
     sorted_data = []
     with open(in_file, 'rb') as csvfile:
@@ -72,6 +72,7 @@ def sort_by_columns(in_file, out_file, column_list):
         csv_data = []
         ind = 0
         for row in unsorted_reader:
+            row = [col_val.strip() for col_val in row]
             if ind > 0:
                 typed_row = create_typed_row(row, column_list)
                 csv_data.append(typed_row)

--- a/sort_by_columns.py
+++ b/sort_by_columns.py
@@ -20,6 +20,7 @@ def cast_to_datetime(dt_str):
         date_time = dt.datetime.strptime(dt_str, gtnp_date_time_format)
     except ValueError as error:
         print error
+        print 'Column cannot be converted to date/time. Sorting will be by string.'
     return date_time
 
 def cast_to_integer(int_str):
@@ -28,7 +29,10 @@ def cast_to_integer(int_str):
     :param int_str: string to convert to an integer
     :return: integer number
     """
-    return int(float(int_str))
+    try:
+        return int(float(int_str))
+    except ValueError:
+        return int_str
 
 def cast_to_real(real_str):
     """
@@ -36,7 +40,10 @@ def cast_to_real(real_str):
     :param real_str: string to convert to a real
     :return: real number
     """
-    return float(real_str)
+    try:
+        return float(real_str)
+    except ValueError:
+        return real_str
 
 def create_typed_row(row, column_list):
     """
@@ -72,7 +79,7 @@ def sort_by_columns(in_file, out_file, column_list):
         csv_data = []
         ind = 0
         for row in unsorted_reader:
-            row = [col_val.strip() for col_val in row]
+            row = [cast_to_real(col_val.strip()) for col_val in row]
             if ind > 0:
                 typed_row = create_typed_row(row, column_list)
                 csv_data.append(typed_row)

--- a/template.json
+++ b/template.json
@@ -1,0 +1,188 @@
+{
+  "name": "",
+  "measure_method": "na",
+  "deepest_sensor": "na",
+  "permafrost_thickness": "na",
+  "slope": "-999.",
+  "aspect": "-999.",
+  "description": "na",
+  "drilling_method": "na",
+  "depth": "0.0",
+  "gtnp": "",
+  "code": "",
+  "drilling_duration": "na",
+  "permafrost_zone": "",
+  "date_drilled": "na",
+  "prior": "na",
+  "angle": "-999.",
+  "diameter": "-999.",
+  "timezone": "na",
+  "created": "",
+  "modified": "",
+  "country_auth": [],
+  "country": "",
+  "geo": {
+    "longitude": "",
+    "latitude": "",
+    "elevation": "-999."
+  },
+  "observation": {
+    "description": "Soil temperatures at meteorological stations",
+    "vegetation": "na",
+    "hydrology": "na",
+    "landform": "na",
+    "lithology": "na",
+    "morphology": "na",
+    "vegetation_name": "na"
+  },
+  "accessibility": {
+    "type": "na",
+    "distance": "na"
+  },
+  "disturbance": {
+    "type": "na",
+    "type2": "na",
+    "distance": "-999.",
+    "distance2": "-999."
+  },
+  "reference": {
+    "content": "",
+    "created": "2015-04-15 10:00:00",
+    "modified": "2015-04-15 10:00:00"
+  },
+  "seo": {
+    "title": "test form",
+    "keywords": "test",
+    "description": "test"
+  },
+  "contact": {
+    "id": 0,
+    "first_name": "NSIDC",
+    "last_name": "User Services",
+    "role": "na",
+    "position": "na",
+    "address": {
+      "address": "449 UCB",
+      "zip": "80309",
+      "region": "na",
+      "city": "Boulder",
+      "country": "USA",
+      "phone": "(303)492-6199",
+      "fax": "(303)492-2468",
+      "url": "na",
+      "email": "nsidc@nsidc.org"
+    },
+    "organization": {
+      "id": 0,
+      "name": "National Snow and Ice Data Center",
+      "acronym": "NSIDC",
+      "sponsor": "University of Colorado",
+      "address": {
+        "address": "449 UCB",
+        "zip": "80309",
+        "region": "na",
+        "city": "Boulder",
+        "country": "USA",
+        "phone": "(303)492-6199",
+        "fax": "(303)492-2468",
+        "url": "na",
+        "email": "nsidc@nsidc.org"
+      }
+    }
+  },
+  "citation": {
+    "id": 0,
+    "doi": "na",
+    "keywords": "Ground Temperature",
+    "title": "Russian historical soil temperature data",
+    "abstract": "This data set is a collection of monthly and annual average soil temperatures measured at Russian meteorological stations.",
+    "version": 1.0,
+    "md_link": "na",
+    "language": "English",
+    "contact": {
+      "id": 0,
+      "first_name": "Roger",
+      "last_name": "Barry",
+      "role": "na",
+      "position": "na",
+      "address": {
+        "address": "449 UCB",
+        "zip": "80309",
+        "region": "na",
+        "city": "Boulder",
+        "country": "USA",
+        "phone": "(303)492-6199",
+        "fax": "(303)492-2468",
+        "url": "na",
+        "email": "nsidc@nsidc.org"
+      },
+      "organization": {
+        "id": 0,
+        "name": "National Snow and Ice Data Center",
+        "acronym": "NSIDC",
+        "sponsor": "University of Colorado",
+        "address": {
+          "address": "449 UCB",
+          "zip": "80309",
+          "region": "na",
+          "city": "Boulder",
+          "country": "USA",
+          "phone": "(303)492-6199",
+          "fax": "(303)492-2468",
+          "url": "na",
+          "email": "nsidc@nsidc.org"
+        }
+      }
+    },
+    "organization": {
+      "id": 0,
+      "name": "National Snow and Ice Data Center",
+      "acronym": "NSIDC",
+      "sponsor": "University of Colorado",
+      "address": {
+        "address": "449 UCB",
+        "zip": "80309",
+        "region": "na",
+        "city": "Boulder",
+        "country": "USA",
+        "phone": "(303)492-6199",
+        "fax": "(303)492-2468",
+        "url": "na",
+        "email": "nsidc@nsidc.org"
+      }
+    }
+  },
+  "dataset": {
+    "description": "This data set is a collection of monthly and annual average soil temperatures measured at Russian meteorological stations.",
+    "policy": "Open",
+    "quality": "Derived Products",
+    "medium": "Soil",
+    "variable": {
+      "Name": "Ground Temperature",
+      "id": "1"
+    },
+    "unit": {
+      "id": "1",
+      "Name": "Degree Celsius",
+      "Abbreviation": "degC",
+      "Variable_id": "1"
+    },
+    "method": {
+      "id": "7",
+      "Name": "Unknown",
+      "Variable": "Ground Temperature"
+    },
+    "datatype": {
+      "id": "1",
+      "Name": "Average"
+    },
+    "frequency": {
+      "id": "16",
+      "Name": "Monthly"
+    },
+    "country_auth": [
+      "Russia",
+      "United States"
+    ]
+  }
+}


### PR DESCRIPTION
This pull request has a few updates from iterations with Kevin to the pull_ggd361_data.py and sort_by_columns.py scripts as well as the addition of the create_gtnp_metadata_json.py script.

To run the pcreate_gtnp_metadata_json.py script:
python create_gtnp_metadata_json.py -t <JSON site entry with common metadata (e.g. template.json)> -c <CSV file with metadata values (e.g. metadata_test.csv)> -o <output JSON file name (e.g. meta.json)>

Included with the create_gtnp_metadata_json.py script are:
- template.json - The template.json file is meant to serve as a JSON template for an individual site/borehole entry in the complete JSON list.  As such the template file should be changed per project to contain the metadata common to all the site/borehole entries.
- metadata_test.csv -An example metadata CSV file.  The number of site/borehole entries in the complete list will be dictated by the CSV file.  The header row of the CSV file should contain the namespaced field names for each JSON field to be modified for each entry.  Each subsequent row of the CSV file then represents one site/borehole JSON entry in the list.  The values in that row will be put in the JSON fields specified in the header row for the entry and the entry added to the site/borehole list.
